### PR TITLE
v1.0.1

### DIFF
--- a/SatFind/src/Tle.hpp
+++ b/SatFind/src/Tle.hpp
@@ -430,12 +430,20 @@ class Tle {
 		int divider = 1;
 		int pointer = 0;
 
-		enum { SignPart, IntegerPart, DecimalPart, FractionPart, ExponentialPart } state = SignPart;
+		enum { SpacePart, SignPart, IntegerPart, DecimalPart, FractionPart, ExponentialPart } state = SpacePart;
 
 		while (pointer < (int)str.length()) {
 			const auto c = str[pointer];
 
 			switch (state) {
+				case SpacePart:
+					if (c == ' ') {
+						pointer++;
+					} else {
+						state = SignPart;
+					}
+					break;
+
 				case SignPart:
 					if (c == '-') {
 						sign_part = -1;
@@ -507,6 +515,7 @@ class Tle {
 			return sign_part * ((double)integer_part + (double)decimal_part / (double)divider);
 		}
 	}
+
 
 	DateTime toDateTime(const std::string& str) {
 		std::int32_t year;


### PR DESCRIPTION
# 概要
TLE変換部の文字列to浮動小数点数変換時にスペースが入るとエラーが出る問題を修正.
桁数が少ないときに先頭にスペースが入るため，無視するよう変更